### PR TITLE
Add map_location device to support loading model on CPU-only devices

### DIFF
--- a/hubconf.py
+++ b/hubconf.py
@@ -72,5 +72,10 @@ def get_trained_boq(backbone_name="resnet50", output_dim=16384):
             aggregator=aggregator
         )
     
-    vpr_model.load_state_dict(torch.hub.load_state_dict_from_url(MODEL_URLS[f"{backbone_name}_{output_dim}"]))
+    vpr_model.load_state_dict(
+        torch.hub.load_state_dict_from_url(
+            MODEL_URLS[f"{backbone_name}_{output_dim}"],
+            map_location=torch.device('cpu')  # Add this line
+        )
+    )
     return vpr_model


### PR DESCRIPTION
Added map_location='cpu' to ensure the model can be loaded on devices without CUDA. This change allows compatibility with CPU-only environments, improving accessibility and broadening device support for users without GPU resources.